### PR TITLE
Remove the `gnupg` Installation from the Setup Step for Linux Runner

### DIFF
--- a/pritunl-client.sh
+++ b/pritunl-client.sh
@@ -59,7 +59,6 @@ install_linux() {
   else
     echo "Installing latest from Prebuilt Apt Repository"
     echo "deb https://repo.pritunl.com/stable/apt $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/pritunl.list
-    sudo apt-get --assume-yes install gnupg
     gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys 7568D9BB55FF9E5287D586017AE645C0CF8E292A
     gpg --armor --export 7568D9BB55FF9E5287D586017AE645C0CF8E292A | sudo tee /etc/apt/trusted.gpg.d/pritunl.asc
     sudo apt-get --assume-yes update


### PR DESCRIPTION
The `gnupg` package is pre-installed by default on the Linux Runner.