### PR TITLE
New Pritunl Client Inputs and Friendly Environment Variables

### DIFF
--- a/.github/workflows/connection-tests.yml
+++ b/.github/workflows/connection-tests.yml
@@ -29,7 +29,7 @@ jobs:
     name: "run:${{ matrix.os }}, vpn:${{ matrix.vpn }}, cv:${{ matrix.client-version }}, sc:${{ matrix.start-connection }}"
 
     env:
-      CONNECTION_TIMEOUT: 15 # Example of overriding default wait established connection timeout
+      PRITUNL_ESTABLISHED_CONNECTION_TIMEOUT: 60 # Example of overriding default wait established connection timeout
 
     steps:
       - name: Checkout
@@ -44,6 +44,8 @@ jobs:
           vpn-mode: ${{ matrix.vpn }}
           client-version: ${{ matrix.client-version }}
           start-connection: ${{ matrix.start-connection }}
+          ready-profile-timeout: '5'
+          established-connection-timeout: '35' # This will be overrided by `PRITUNL_ESTABLISHED_CONNECTION_TIMEOUT` Global Environment Variable set above.
 
       - name: Starting a VPN Connection Manually
         if: ${{ matrix.start-connection == 'false' }}
@@ -88,7 +90,7 @@ jobs:
           # Function to wait for an established connection
           wait_established_connection() {
             # Define the total number of steps
-            local total_steps="${CONNECTION_TIMEOUT}"
+            local total_steps="${PRITUNL_ESTABLISHED_CONNECTION_TIMEOUT}"
 
             # Initialize the current step variable
             local current_step=0
@@ -175,11 +177,11 @@ jobs:
         shell: bash
         run: |
           # VPN Gateway Reachability Test
-          PING_FLAG="$([[ "$RUNNER_OS" == "Windows" ]] && echo "-n 10" || echo "-c 10")"
-          HOST="$(pritunl-client list | awk -F '|' 'NR==4{print $8}' | xargs ipcalc | awk 'NR==6{print $2}')"
+          ping_flags="$([[ "$RUNNER_OS" == "Windows" ]] && echo "-n 10" || echo "-c 10")"
+          vpn_gateway="$(pritunl-client list | awk -F '|' 'NR==4{print $8}' | xargs ipcalc | awk 'NR==6{print $2}')"
 
           # Ping VPN Gateway
-          ping $PING_FLAG $HOST
+          ping $ping_flags $vpn_gateway
 
       - name: Stop VPN Connection Manually
         shell: bash

--- a/README.md
+++ b/README.md
@@ -127,6 +127,16 @@ The configuration is declarative and relatively simple to use.
     # If not supplied, which defaults to `true`.
     # If `true` the VPN connection starts within the setup step.
     start-connection: ''
+
+    ready-profile-timeout: ''
+    # OPTIONAL: Ready Profile Timeout
+    # TYPE: Integer
+    # If not supplied, which defaults to `3`.
+
+    established-connection-timeout: ''
+    # OPTIONAL: Established Connection Timeout
+    # TYPE: Integer
+    # If not supplied, which defaults to `30`.
 ```
 
 > Kindly check the subsection [Working with Pritunl Profile File](#working-with-pritunl-profile-file) on converting `tar` archive file format to `base64` text file format for the `profile-file` input.
@@ -287,7 +297,7 @@ _Then your other steps down below._
   with:
     profile-file: ${{ secrets.PRITUNL_PROFILE_FILE }}
   env:
-    CONNECTION_TIMEOUT: 20 # Example of a connection timeout after 20 attempts while waiting for an established connection.
+    PRITUNL_ESTABLISHED_CONNECTION_TIMEOUT: 60 # Example of a connection timeout after 60 attempts while waiting for an established connection.
 ```
 
 > Kindly check the GitHub Action workflow file [connection-tests.yml](./.github/workflows/connection-tests.yml) for the complete working example.

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,16 @@ inputs:
     required: false
     default: 'true'
 
+  ready-profile-timeout:
+    description: 'Wait for Ready Profile Timeout.'
+    required: false
+    default: '3'
+
+  established-connection-timeout:
+    description: 'Wait for Established Connection Timeout.'
+    required: false
+    default: '30'
+
 outputs:
   client-id:
     description: "Pritunl Client ID"
@@ -38,11 +48,13 @@ runs:
     - name: Setup Pritunl Client
       id: pritunl-client
       env:
-        PROFILE_FILE: ${{ inputs.profile-file }}
-        PROFILE_PIN: ${{ inputs.profile-pin }}
-        VPN_MODE: ${{ inputs.vpn-mode }}
-        CLIENT_VERSION: ${{ inputs.client-version }}
-        START_CONNECTION: ${{ inputs.start-connection }}
+        PRITUNL_PROFILE_FILE: ${{ inputs.profile-file }}
+        PRITUNL_PROFILE_PIN: ${{ inputs.profile-pin }}
+        PRITUNL_VPN_MODE: ${{ inputs.vpn-mode }}
+        PRITUNL_CLIENT_VERSION: ${{ inputs.client-version }}
+        PRITUNL_START_CONNECTION: ${{ inputs.start-connection }}
+        PRITUNL_READY_PROFILE_TIMEOUT: ${{ inputs.ready-profile-timeout }}
+        PRITUNL_ESTABLISHED_CONNECTION_TIMEOUT: ${{ inputs.established-connection-timeout }}
       shell: bash
       run: |
         "$GITHUB_ACTION_PATH$([[ "$RUNNER_OS" == "Windows" ]] && echo '\\' || echo '/')pritunl-client.sh"


### PR DESCRIPTION
Added 2 New Inputs

```yaml
- uses: nathanielvarona/pritunl-client-github-action@v1
  with:
    ...
    ...
    ready-profile-timeout: ''
    established-connection-timeout: ''
```

And friendly names for Environment Variables if used as overrides.
```
PRITUNL_PROFILE_FILE
PRITUNL_PROFILE_PIN
PRITUNL_VPN_MODE
PRITUNL_CLIENT_VERSION
PRITUNL_START_CONNECTION
PRITUNL_READY_PROFILE_TIMEOUT
PRITUNL_ESTABLISHED_CONNECTION_TIMEOUT
```