### PR TITLE
Profile Server Input Options Usage

### DIFF
--- a/.github/workflows/connection-tests-basic.yml
+++ b/.github/workflows/connection-tests-basic.yml
@@ -1,4 +1,4 @@
-name: Connection Tests
+name: Connection Tests - Basic
 
 on:
   workflow_dispatch:

--- a/.github/workflows/connection-tests-complete.yml
+++ b/.github/workflows/connection-tests-complete.yml
@@ -1,4 +1,4 @@
-name: Connection Tests
+name: Connection Tests - Complete
 
 on:
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ The configuration is declarative and relatively simple to use.
     # TYPE: String (Numerical values)
     # If not supplied, which defaults No Pin.
 
+    profile-server: ''
+    # OPTIONAL: Profile Server
+    # TYPE: String
+    # If not supplied, which defaults to first profile server.
+
     vpn-mode: ''
     # OPTIONAL: VPN Connection Mode
     # TYPE: String
@@ -197,6 +202,18 @@ _Then your other steps down below._
     profile-pin: ${{ secrets.PRITUNL_PROFILE_PIN }}
 ```
 
+### If the profile has multiple servers and want to specify one
+
+
+```yml
+- name: Setup Pritunl Profile and Start VPN Connection
+  uses: nathanielvarona/pritunl-client-github-action@v1
+  with:
+    profile-file: ${{ secrets.PRITUNL_PROFILE_FILE }}
+    ...
+    profile-server: 'pritunl-dev-2'
+```
+
 
 ### Or using a Specific Version of the Client and a WireGuard for the VPN Mode
 
@@ -205,7 +222,7 @@ _Then your other steps down below._
   uses: nathanielvarona/pritunl-client-github-action@v1
   with:
     profile-file: ${{ secrets.PRITUNL_PROFILE_FILE }}
-    profile-pin: ${{ secrets.PRITUNL_PROFILE_PIN }}
+    ...
     client-version: '1.3.3637.72'
     vpn-mode: 'wg'
 ```
@@ -218,23 +235,27 @@ _Then your other steps down below._
   uses: nathanielvarona/pritunl-client-github-action@v1
   with:
     profile-file: ${{ secrets.PRITUNL_PROFILE_FILE }}
+    ...
     start-connection: false # Do not establish a connection in this step.
 
 - name: Starting a VPN Connection Manually
   shell: bash
   run: |
+
     pritunl-client start ${{ steps.pritunl-connection.outputs.client-id }} \
       --password ${{ secrets.PRITUNL_PROFILE_PIN }}
 
 - name: Show VPN Connection Status Manually
   shell: bash
   run: |
+
     sleep 10
     pritunl-client list
 
 - name: Your CI/CD Core Logic
   shell: bash
   run: |
+
     ##
     # Below is our simple example for VPN connectivity test.
     ##
@@ -274,19 +295,8 @@ _Then your other steps down below._
   if: ${{ always() }}
   shell: bash
   run: |
+
     pritunl-client stop ${{ steps.pritunl-connection.outputs.client-id }}
-```
-
-### Overriding default wait established connection timeout
-
-```yml
-- name: Setup Pritunl Profile
-  id: pritunl-connection
-  uses: nathanielvarona/pritunl-client-github-action@v1
-  with:
-    profile-file: ${{ secrets.PRITUNL_PROFILE_FILE }}
-  env:
-    PRITUNL_ESTABLISHED_CONNECTION_TIMEOUT: 60 # Example of a connection timeout after 60 attempts while waiting for an established connection.
 ```
 
 > Kindly check the GitHub Action workflow file `./.github/workflows/connection-tests.yml` for the complete working example.
@@ -302,9 +312,7 @@ To store Pritunl Profile to GitHub Secrets, maintaining the raw state of the `ta
 #### 1. Download the Pritunl Profile File obtained from the Pritunl User Profile Page
 
 ```bash
-curl --silent --show-error \
-  --location https://vpn.domain.tld/key/xxxxxxxxxxxxxx.tar \
-  --output ./pritunl.profile.tar
+curl -sSL https://vpn.domain.tld/key/xxxxxxxxxxxxxx.tar -o ./pritunl.profile.tar
 ```
 
 #### 2. Convert your Pritunl Profile File from `tar` archive file format to `base64` text file format.

--- a/pritunl-client.sh
+++ b/pritunl-client.sh
@@ -198,7 +198,6 @@ get_profile_server() {
   )
 
   if [[ -n "$PRITUNL_PROFILE_SERVER" ]]; then
-    echo "Using specific profile server..." >&2
     profile_server_json=$(
       echo "$profile_list_json" |
         jq ".[] | select(.name | contains(\"$PRITUNL_PROFILE_SERVER\"))"
@@ -211,7 +210,6 @@ get_profile_server() {
       exit 1
     fi
   else
-    echo "Using default profile server..." >&2
     echo "$profile_list_json" |
       jq ".[0]"
   fi


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

### Pull Request Description
<!-- Provide a clear and concise description of the changes you want to merge. -->

Added Usage Guide for Profile Server

```yaml
- name: Setup Pritunl Profile and Start VPN Connection
  uses: nathanielvarona/pritunl-client-github-action@v1
  with:
    profile-file: ${{ secrets.PRITUNL_PROFILE_FILE }}
    ...
    profile-server: profile-server
```

<!-- ### Related Issues -->
<!-- Please provide the links of related issues: -->
<!-- https://github.com/nathanielvarona/pritunl-client-github-action/issues/[ISSUE NUMBER] -->

<!-- ### Motivation and Context -->
<!-- Why is this change required? What problem does it solve? -->

<!-- ### Types of changes -->
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--
- [ ] Improvements
- [ ] Fixes
- [ ] Automation
- [ ] Documentation 
-->

### It has been tested with the following parameters:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

**Runner Virtual Environments:**
- Linux
  - [ ] Ubuntu 22.04
  - [ ] Ubuntu 20.04
- macOS
  - [ ] macOS 12
  - [ ] macOS 11
- Windows
  - [ ] Windows 2022
  - [ ] Windows 2019

**VPN Modes:**
- [x] OpenVPN (ovpn) <!-- default -->
- [ ] WireGuard (wg)

**Client Versions:**
- [x] Installed from the package manager <!-- default -->
- Version specific
  <!-- Please specify the versions of the Pritunl Client that you are currently using. -->
  - [ ] 1.3.3637.72

**Start Connection:** *If the connection is started on the setup step.*
- [x] True <!-- default -->
- [ ] False

**Runner Types:**
- [x] Tested on GitHub-hosted runner <!-- only tested working -->
- Tested on Self-Hosted runner

  *If it runs on a self-hosted runner:*
  - [ ] Manage Self-hosted
  - [ ] Action Runner Controller (ARC) (a Kubernetes Operator)