### PR TITLE
Validate Base64 Data and Load the Profile File on the Fly

### DIFF
--- a/.github/workflows/connection-tests-complete.yml
+++ b/.github/workflows/connection-tests-complete.yml
@@ -29,7 +29,7 @@ jobs:
           - false
 
     runs-on: ${{ matrix.os }}
-    name: "run:${{ matrix.os }}, ps:${{ matrix.profile-server || 'pritunl-dev-1'  }}, vpn:${{ matrix.vpn-mode }}, cv:${{ matrix.client-version }}, sc:${{ matrix.start-connection }}"
+    name: "run:${{ matrix.os }}, ps:${{ matrix.profile-server }}, vpn:${{ matrix.vpn-mode }}, cv:${{ matrix.client-version }}, sc:${{ matrix.start-connection }}"
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Runner         | OpenVPN                | WireGuard
 `windows-2022` | :white_check_mark: yes | :white_check_mark: yes
 `windows-2019` | :white_check_mark: yes | :white_check_mark: yes
 
-> Kindly check out the comprehensive test connection matrix available on our GitHub Actions page.
+> Kindly check out the comprehensive connection tests matrix available on our GitHub Actions page.
 
 _Tested working on **`Pritunl v1.32.3602.80`** Server._
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

### Pull Request Description
<!-- Provide a clear and concise description of the changes you want to merge. -->

Validate Base64 Data and Load the Profile File on the Fly.

<!-- ### Related Issues -->
<!-- Please provide the links of related issues: -->
<!-- https://github.com/nathanielvarona/pritunl-client-github-action/issues/[ISSUE NUMBER] -->

<!-- ### Motivation and Context -->
<!-- Why is this change required? What problem does it solve? -->

<!-- ### Types of changes -->
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--
- [x] Improvements
- [ ] Fixes
- [ ] Automation
- [ ] Documentation 
-->

### It has been tested with the following parameters:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

**Runner Virtual Environments:**
- Linux
  - [x] Ubuntu 22.04
  - [ ] Ubuntu 20.04
- macOS
  - [x] macOS 12
  - [ ] macOS 11
- Windows
  - [x] Windows 2022
  - [ ] Windows 2019

**VPN Modes:**
- [x] OpenVPN (ovpn) <!-- default -->
- [ ] WireGuard (wg)

**Client Versions:**
- [x] Installed from the package manager <!-- default -->
- Version specific
  <!-- Please specify the versions of the Pritunl Client that you are currently using. -->
  - [ ] 1.3.3637.72

**Start Connection:** *If the connection is started on the setup step.*
- [x] True <!-- default -->
- [ ] False

**Runner Types:**
- [x] Tested on GitHub-hosted runner <!-- only tested working -->
- Tested on Self-Hosted runner

  *If it runs on a self-hosted runner:*
  - [ ] Manage Self-hosted
  - [ ] Action Runner Controller (ARC) (a Kubernetes Operator)