### PR TITLE
Support for macOS Runner ARM64 Architecture

### DIFF
--- a/pritunl-client.sh
+++ b/pritunl-client.sh
@@ -84,18 +84,21 @@ install_for_macos() {
 
     local pritunl_install_file
     local pkg_zip_url
+    local pkg_arch
 
     validate_client_version "$PRITUNL_CLIENT_VERSION"
 
-    pritunl_install_file="$RUNNER_TEMP/Pritunl.pkg.zip"
-    pkg_zip_url="https://github.com/pritunl/pritunl-client-electron/releases/download/$PRITUNL_CLIENT_VERSION/Pritunl.pkg.zip"
+    pkg_arch=$([[ "$RUNNER_ARCH" == "ARM64" ]] && echo 'arm64.' || echo '')
+
+    pritunl_install_file="$RUNNER_TEMP/Pritunl.${pkg_arch}pkg.zip"
+    pkg_zip_url="https://github.com/pritunl/pritunl-client-electron/releases/download/$PRITUNL_CLIENT_VERSION/Pritunl.${pkg_arch}pkg.zip"
 
     curl -sSL "$pkg_zip_url" -o "$pritunl_install_file"
     unzip -qq -o "$pritunl_install_file" -d "$RUNNER_TEMP"
 
     # Installing using MacOS `installer` a system software and .pkg package installer tool
-    if sudo installer -pkg "$RUNNER_TEMP/Pritunl.pkg" -target /; then
-      rm -f "$pritunl_install_file" "$RUNNER_TEMP/Pritunl.pkg"
+    if sudo installer -pkg "$RUNNER_TEMP/Pritunl.${pkg_arch}pkg" -target /; then
+      rm -f "$pritunl_install_file" "$RUNNER_TEMP/Pritunl.${pkg_arch}pkg"
     fi
   fi
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

### Pull Request Description
<!-- Provide a clear and concise description of the changes you want to merge. -->

<!-- ### Related Issues -->
<!-- Please provide the links of related issues: -->
<!-- https://github.com/nathanielvarona/pritunl-client-github-action/issues/[ISSUE NUMBER] -->

<!-- ### Motivation and Context -->
<!-- Why is this change required? What problem does it solve? -->

<!-- ### Types of changes -->
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--
- [x] Improvements
- [ ] Fixes
- [ ] Automation
- [ ] Documentation 
-->

### It has been tested with the following parameters:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

**Runner Virtual Environments:**
- Linux
  - [ ] Ubuntu 22.04
  - [ ] Ubuntu 20.04
- macOS
  - [x] macOS 13
  - [ ] macOS 12
- Windows
  - [ ] Windows 2022
  - [ ] Windows 2019

**VPN Modes:**
- [ ] OpenVPN (ovpn) <!-- default -->
- [ ] WireGuard (wg)

**Client Versions:**
- [x] Installed from the package manager <!-- default -->
- Version specific
  <!-- Please specify the versions of the Pritunl Client that you are currently using. -->
  - [x] 1.3.3709.64

**Start Connection:** *If the connection is started on the setup step.*
- [ ] True <!-- default -->
- [x] False

**Runner Types:**
- [x] Tested on GitHub-hosted runner <!-- only tested working -->
- Tested on Self-Hosted runner

  *If it runs on a self-hosted runner:*
  - [ ] Manage Self-hosted
  - [ ] Action Runner Controller (ARC) (a Kubernetes Operator)