### PR TITLE
Less Noisy for Linux Aptitude Install

### DIFF
--- a/pritunl-client.sh
+++ b/pritunl-client.sh
@@ -39,7 +39,7 @@ install_for_linux() {
     echo "deb https://repo.pritunl.com/stable/apt $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/pritunl.list
     gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys 7568D9BB55FF9E5287D586017AE645C0CF8E292A > /dev/null 2>&1
     gpg --armor --export 7568D9BB55FF9E5287D586017AE645C0CF8E292A | sudo tee /etc/apt/trusted.gpg.d/pritunl.asc > /dev/null
-    sudo apt-get update -qq -y && sudo apt-get install -qq -y pritunl-client
+    sudo apt-get update -qq -y && sudo apt-get install -qq -o=Dpkg::Use-Pty=0 -y pritunl-client
 
   else
     # Installing Version Specific using Debian Package from Pritunl GitHub Releases
@@ -57,7 +57,7 @@ install_for_linux() {
     curl -sSL "$deb_url" -o "$pritunl_install_file"
 
     # Installing using APT package handling utility
-    if sudo apt-get install -qq -y "$pritunl_install_file"; then
+    if sudo apt-get install -qq -o=Dpkg::Use-Pty=0 -y "$pritunl_install_file"; then
       rm -f "$pritunl_install_file"
     fi
   fi
@@ -179,11 +179,11 @@ install_vpn_dependencies() {
     Linux)
       # Install base dependent packages for `pritunl-client` on Linux
       sudo apt-get update -qq -y
-      sudo apt-get install -qq -y net-tools iptables openvpn resolvconf
+      sudo apt-get install -qq -o=Dpkg::Use-Pty=0 -y net-tools iptables openvpn resolvconf
       if [[ "$PRITUNL_VPN_MODE" == "ovpn" ]]; then
-        sudo apt-get install -qq -y openvpn-systemd-resolved
+        sudo apt-get install -qq -o=Dpkg::Use-Pty=0 -y openvpn-systemd-resolved
       elif [[ "$PRITUNL_VPN_MODE" == "wg" ]]; then
-        sudo apt-get install -qq -y wireguard-tools
+        sudo apt-get install -qq -o=Dpkg::Use-Pty=0 -y wireguard-tools
       fi
       ;;
     macOS)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

### Pull Request Description
<!-- Provide a clear and concise description of the changes you want to merge. -->

<!-- ### Related Issues -->
<!-- Please provide the links of related issues: -->
<!-- https://github.com/nathanielvarona/pritunl-client-github-action/issues/[ISSUE NUMBER] -->

<!-- ### Motivation and Context -->
<!-- Why is this change required? What problem does it solve? -->

<!-- ### Types of changes -->
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--
- [x] Improvements
- [ ] Fixes
- [ ] Automation
- [ ] Documentation 
-->

### It has been tested with the following parameters:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

**Runner Virtual Environments:**
- Linux
  - [x] Ubuntu 22.04
  - [x] Ubuntu 20.04
- macOS
  - [ ] macOS 13
  - [ ] macOS 12
- Windows
  - [ ] Windows 2022
  - [ ] Windows 2019

**VPN Modes:**
- [ ] OpenVPN (ovpn) <!-- default -->
- [ ] WireGuard (wg)

**Client Versions:**
- [x] Installed from the package manager <!-- default -->
- Version specific
  <!-- Please specify the versions of the Pritunl Client that you are currently using. -->
  - [x] 1.3.3814.40

**Start Connection:** *If the connection is started on the setup step.*
- [ ] True <!-- default -->
- [ ] False

**Runner Types:**
- [x] Tested on GitHub-hosted runner <!-- only tested working -->
- Tested on Self-Hosted runner

  *If it runs on a self-hosted runner:*
  - [ ] Manage Self-hosted
  - [ ] Action Runner Controller (ARC) (a Kubernetes Operator)