### PR TITLE
Concealed Outputs by Default

### DIFF
--- a/.github/workflows/connection-tests-multi-server-profile.yml
+++ b/.github/workflows/connection-tests-multi-server-profile.yml
@@ -15,6 +15,9 @@ jobs:
         profile-server:
           - pritunl.server.1
           - pritunl.server.1, pritunl.server.2
+        concealed-outputs:
+          - true
+          - false
 
     runs-on: ${{ matrix.os }}
     name: "run:${{ matrix.os }}, ps:'${{ matrix.profile-server }}'"
@@ -29,6 +32,7 @@ jobs:
         with:
           profile-file: ${{ secrets.PRITUNL_PROFILE_FILE_MULTI_SERVER }}
           profile-server: ${{ matrix.profile-server }}
+          concealed-outputs: ${{ matrix.concealed-outputs }}
 
       - name: Install IP Tooling (IP Calculator)
         shell: bash

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The configuration is declarative and relatively simple to use.
     start-connection: '' # OPTIONAL: Start the Connection (Boolean, default: true)
     ready-profile-timeout: '' # OPTIONAL: Ready Profile Timeout (Natural Numbers, unit of time in seconds, default: 3)
     established-connection-timeout: '' # OPTIONAL: Established Connection Timeout (Natural Numbers, unit of time in seconds, default: 30)
+    concealed-outputs: '' # OPTIONAL: Concealed Outputs (Boolean, default: true)
 ```
 
 > [!IMPORTANT]
@@ -63,19 +64,36 @@ The configuration is declarative and relatively simple to use.
 ### Outputs
 
 * `client-id` — a string representing the primary client ID, which is a single identifier generated during the profile setup process.
-* `client-ids` — a JSON array containing all client IDs and names in the profile, with each entry represented as a key-value pair (e.g., `{ "name": "profile_name", "id": "client_id" }`).
+  - Example:
+    ```
+    client_id="kp4kx4zbcqpsqkbk"
+    ```
+* `client-ids` — a JSON array containing all client IDs and names in the profile, with each entry represented as a key-value pair (e.g., `{"id":"client_id","name":"profile_name"}`).
+
+  - Example _(single entry)_:
+    ```
+    client-ids="[{"id":"6p5yiqbkjbktkrz5","name":"cicd.automation (dev-team)"}]"
+    ```
+  - Example _(multiple entries)_:
+    ```
+    client-ids="[{"id":"kp4kx4zbcqpsqkbk","name":"cicd.automation (dev-team)"},{"id":"rsy6npzw5mwryge2","name":"cicd.automation (qa-team)"}]"
+    ```
+
 
 The step output retrieving examples are:
 * `${{ steps.pritunl-connection.outputs.client-id }}`, for the primary client ID.
 * `${{ steps.pritunl-connection.outputs.client-ids }}`, for the list of client IDs.
 
-_Note: `pritunl-connection` refers to the `Setup Step ID`._
+_Note: `pritunl-connection` refers to the **Setup Step ID**._
 
 > [!TIP]
-> Please see the subsection [Manually Controlling the Connection](#and-even-manually-controlling-the-connection) for an example of using `client-id`.
+> Please see the subsection "[Manually Controlling the Connection](#and-even-manually-controlling-the-connection)" for an example of using `client-id`.
+
+> [!TIP]
+> Please see the subsection "[If the profile has multiple servers and want to specify one or more](#if-the-profile-has-multiple-servers-and-want-to-specify-one-or-more)" for examples of using `client-ids`.
 
 > [!IMPORTANT]
-> See also the workflow file [connection-tests-complete.yml](./.github/workflows/connection-tests-complete.yml) for a complete tests matrix example, including the usage of `client-ids` output.
+> See also the workflow file [connection-tests-complete.yml](./.github/workflows/connection-tests-complete.yml) for a complete tests matrix example.
 
 
 ## Examples

--- a/action.yml
+++ b/action.yml
@@ -42,13 +42,18 @@ inputs:
     required: false
     default: '30'
 
+  concealed-outputs:
+    description: Concealed Outputs (true/false)
+    required: false
+    default: 'true'
+
 outputs:
   client-id:
-    description: Primary Client ID
+    description: Primary Client ID (string, bash variable)
     value: ${{ steps.pritunl-client.outputs.client-id }}
 
   client-ids:
-    description: All Client IDs and Names
+    description: All Client IDs and Names (JSON array)
     value: ${{ steps.pritunl-client.outputs.client-ids }}
 
 runs:
@@ -66,6 +71,7 @@ runs:
         PRITUNL_START_CONNECTION: ${{ inputs.start-connection }}
         PRITUNL_READY_PROFILE_TIMEOUT: ${{ inputs.ready-profile-timeout }}
         PRITUNL_ESTABLISHED_CONNECTION_TIMEOUT: ${{ inputs.established-connection-timeout }}
+        PRITUNL_CONCEALED_OUTPUTS: ${{ inputs.concealed-outputs }}
       shell: bash
       run: |
         # pritunl-client.sh


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

### Pull Request Description
<!-- Provide a clear and concise description of the changes you want to merge. -->

<!-- ### Related Issues -->
<!-- Please provide the links of related issues: -->
<!-- https://github.com/nathanielvarona/pritunl-client-github-action/issues/[ISSUE NUMBER] -->

<!-- ### Motivation and Context -->
<!-- Why is this change required? What problem does it solve? -->

<!-- ### Types of changes -->
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--
- [ ] Improvements
- [ ] Fixes
- [ ] Automation
- [ ] Documentation 
-->

### It has been tested with the following parameters:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

**Runner Virtual Environments:**
- Linux
  - [ ] Ubuntu 22.04
  - [ ] Ubuntu 20.04
- macOS
  - [ ] macOS 13
  - [ ] macOS 12
- Windows
  - [ ] Windows 2022
  - [ ] Windows 2019

**VPN Modes:**
- [x] OpenVPN (ovpn) <!-- default -->
- [ ] WireGuard (wg)

**Client Versions:**
- [x] Installed from the package manager <!-- default -->
- Version specific
  <!-- Please specify the versions of the Pritunl Client that you are currently using. -->
  - [ ] 1.3.3814.40

**Start Connection:** *If the connection is started on the setup step.*
- [x] True <!-- default -->
- [ ] False

**Runner Types:**
- [x] Tested on GitHub-hosted runner <!-- only tested working -->
- Tested on Self-Hosted runner

  *If it runs on a self-hosted runner:*
  - [ ] Manage Self-hosted
  - [ ] Action Runner Controller (ARC) (a Kubernetes Operator)