### PR TITLE
Action Entrypoint OS Path Separator Function

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -78,32 +78,27 @@ runs:
         PRITUNL_CONCEALED_OUTPUTS: ${{ inputs.concealed-outputs }}
       shell: bash
       run: |
-        # Main entry point for executing the 'pritunl-client.sh' script
+        # main entry point for executing the 'pritunl-client.sh' script
 
-        # Define the 'pritunl_client' function, which sets up and runs the script
-        pritunl_client() {
-          # Declare a local variable to store the path 'separator', to avoid polluting the global namespace
-          local separator
-
+        # Define a function to determine the path separator based on the runner OS
+        os_path_separator() {
           # Determine the path separator based on the runner OS
           case "${RUNNER_OS}" in
             Windows)
-              # Use a backslash (\) for Windows paths
-              separator='\'
+              # Use a backslash (\) for Windows paths to avoid file name confusion
+              echo '\'
               ;;
             *)
-              # Use a forward slash (/) for non-Windows OSes (Linux, macOS, etc.)
-              separator='/'
+              # Use a forward slash (/) for non-Windows OSes (Linux, macOS, etc.) for consistency
+              echo '/'
               ;;
           esac
-
-          # Construct the full path to the 'pritunl-client.sh' script using 'GITHUB_ACTION_PATH' and the 'separator'
-          # and run the script
-          "${GITHUB_ACTION_PATH}${separator}pritunl-client.sh"
         }
 
-        # Call the 'pritunl_client' function to start the script execution
-        pritunl_client
+        # Run the 'pritunl-client.sh' script using the dynamically constructed path
+        # The path is constructed by combining 'GITHUB_ACTION_PATH' with the appropriate path separator by OS
+        # and the script name 'pritunl-client.sh' to ensure correct script execution
+        ${GITHUB_ACTION_PATH}$(os_path_separator)pritunl-client.sh
 
 # Define branding for the GitHub Marketplace
 branding:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

### Pull Request Description
<!-- Provide a clear and concise description of the changes you want to merge. -->

<!-- ### Related Issues -->
<!-- Please provide the links of related issues: -->
<!-- https://github.com/nathanielvarona/pritunl-client-github-action/issues/[ISSUE NUMBER] -->

<!-- ### Motivation and Context -->
<!-- Why is this change required? What problem does it solve? -->

<!-- ### Types of changes -->
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--
- [ ] Improvements
- [ ] Fixes
- [ ] Automation
- [ ] Documentation 
-->

### It has been tested with the following parameters:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

**Runner Virtual Environments:**
- Linux
  - [ ] Ubuntu 22.04
  - [ ] Ubuntu 20.04
- macOS
  - [ ] macOS 13
  - [ ] macOS 12
- Windows
  - [ ] Windows 2022
  - [ ] Windows 2019

**VPN Modes:**
- [x] OpenVPN (ovpn) <!-- default -->
- [ ] WireGuard (wg)

**Client Versions:**
- [x] Installed from the package manager <!-- default -->
- Version specific
  <!-- Please specify the versions of the Pritunl Client that you are currently using. -->
  - [ ] 1.3.3814.40

**Start Connection:** *If the connection is started on the setup step.*
- [x] True <!-- default -->
- [ ] False

**Runner Types:**
- [x] Tested on GitHub-hosted runner <!-- only tested working -->
- Tested on Self-Hosted runner

  *If it runs on a self-hosted runner:*
  - [ ] Manage Self-hosted
  - [ ] Action Runner Controller (ARC) (a Kubernetes Operator)