### PR TITLE
fix: download client binaries from pritunl/pritunl-client (electron repo 404s for current releases)

### DIFF
--- a/pritunl-client.sh
+++ b/pritunl-client.sh
@@ -98,7 +98,7 @@ install_for_linux() {
     # Set install file path
     pritunl_install_file="${RUNNER_TEMP}/pritunl-client.deb"
     # Set download URL
-    deb_url="https://github.com/pritunl/pritunl-client-electron/releases/download/${PRITUNL_CLIENT_VERSION}/pritunl-client_${PRITUNL_CLIENT_VERSION}-0ubuntu1.$(lsb_release -cs)_amd64.deb"
+    deb_url="https://github.com/pritunl/pritunl-client/releases/download/${PRITUNL_CLIENT_VERSION}/pritunl-client_${PRITUNL_CLIENT_VERSION}-0ubuntu1.$(lsb_release -cs)_amd64.deb" # releases served from pritunl/pritunl-client since v1.3.3884.0
 
     # Download the Debian package
     curl -sSL "$deb_url" -o "$pritunl_install_file"
@@ -143,7 +143,7 @@ install_for_macos() {
 
     # Set install file path and download URL
     pritunl_install_file="${RUNNER_TEMP}/Pritunl.pkg.zip"
-    pkg_zip_url="https://github.com/pritunl/pritunl-client-electron/releases/download/${PRITUNL_CLIENT_VERSION}/Pritunl.pkg.zip"
+    pkg_zip_url="https://github.com/pritunl/pritunl-client/releases/download/${PRITUNL_CLIENT_VERSION}/Pritunl.pkg.zip" # releases served from pritunl/pritunl-client since v1.3.3884.0
 
     # Download the package
     curl -sSL "$pkg_zip_url" -o "$pritunl_install_file"
@@ -200,7 +200,7 @@ install_for_windows() {
 
     # Set install file path and download URL
     pritunl_install_file="${RUNNER_TEMP}\Pritunl.exe"
-    exe_url="https://github.com/pritunl/pritunl-client-electron/releases/download/${PRITUNL_CLIENT_VERSION}/Pritunl.exe"
+    exe_url="https://github.com/pritunl/pritunl-client/releases/download/${PRITUNL_CLIENT_VERSION}/Pritunl.exe" # releases served from pritunl/pritunl-client since v1.3.3884.0
 
     # Download the executable
     curl -sSL "$exe_url" -o "$pritunl_install_file"


### PR DESCRIPTION
## Problem

The action downloads Pritunl client packages from `pritunl/pritunl-client-electron` releases, but recent client versions (since v1.3.3884.0) are published under the [`pritunl/pritunl-client`](https://github.com/pritunl/pritunl-client/releases) repository instead. As a result, installing current versions fails with a 404 on the download URL.

## Fix

Update the Linux (`.deb`), macOS (`Pritunl.pkg.zip`), and Windows (`Pritunl.exe`) download URLs in `pritunl-client.sh` to point at `pritunl/pritunl-client` releases. No other logic changes — filenames and version templating are unchanged.

AI-Assisted-By: Claude Code